### PR TITLE
Feature/use android localhost proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Svelte + Capacitor (w/ live reload) Template
 
-This is a project template for [Svelte](https://svelte.dev) + [CapacitorJS](https://capacitorjs.com) apps with live reload. 
+This is a project template for [Svelte](https://svelte.dev) + [CapacitorJS](https://capacitorjs.com) apps with live reload.
 
 *Note that you will need to have [Node.js](https://nodejs.org) installed.*
 
@@ -29,9 +29,11 @@ npx cap add android // (or ios)
 
 ### Develop on your device with livereload (hot reload)
 
-You will need to append your workstation IP to the `server.url` section in `capacitor.config.json`
+If you're only targeting Android, you only need to change the `server.url` section in `capacitor.config.json` to use `http://10.0.2.2:5001`, since [Android Studio already adds a `localhost` proxy](https://stackoverflow.com/questions/9808560/why-do-we-use-10-0-2-2-to-connect-to-local-web-server-instead-of-using-computer). Just remember to remove it when building your app for production.
 
-Tip: Remember you will need the `http://` before the server ip. 
+If you're targeting iOS or both, you will need to append your workstation IP to the `server.url` section in `capacitor.config.json` instead. To discover your workstation IP, just run `ifconfig` or find it on the network settings.
+
+Tip: Remember you will need the `http://` before the server ip.
 
 Back in the root folder:
 
@@ -41,7 +43,7 @@ This will run the capacitor/svelte project with a web view pointing to your work
 
 Try to change something in App.svelte, and you should see the content reload in your device.
 
-* You need to have an emulator/device connected to adb 
+* You need to have an emulator/device connected to adb
 * Your device has to be connected to the same wifi network as your workstation.
 
 ### To build a production application:
@@ -56,9 +58,9 @@ Try to change something in App.svelte, and you should see the content reload in 
 
 You can use any Chromioum-based browser and use their Developer Tools (for Android atleast, have not tested iOS) to debug and access console commands on your personal device, by going to chrome://inspect#devices., edge://inspect#devices., vivaldi://inspect#devices., brave://inspect#devices, &c.
 
-The standard web inspector will also work for debugging and rewriting styling and html without using your IDE just like when building a normal website. This may have some issues with some forms of SVG-related svelte templating (I have had issues with using some chart libraries displaying in the web inspector), they will still show up on the device but not in the preview.  
+The standard web inspector will also work for debugging and rewriting styling and html without using your IDE just like when building a normal website. This may have some issues with some forms of SVG-related svelte templating (I have had issues with using some chart libraries displaying in the web inspector), they will still show up on the device but not in the preview.
 
-You may use the address bar in the developer tools to navigate to direct views in your application, even without any tappable links to do so. This allows you to create hidden routes for testing. 
+You may use the address bar in the developer tools to navigate to direct views in your application, even without any tappable links to do so. This allows you to create hidden routes for testing.
 
 ### Routing Libraries
 Since this is a Svelte applicaiton you will be able to use any routing manager that you prefer. I prefer routify, but others such as:
@@ -66,17 +68,17 @@ Since this is a Svelte applicaiton you will be able to use any routing manager t
  - ItalyPaleAple/svelte-spa-router - https://github.com/ItalyPaleAle/svelte-spa-router
  - EmilTholin/svelte-routing - https://github.com/EmilTholin/svelte-routing
  - orgegorka/svelte-router - https://github.com/jorgegorka/svelte-router
- 
- ### Accessing Device APIs 
- CapacitorJS is/was based on Cordova and has *complete* backwards compatibility with cordova plugins. To find plugins that allow you to access the device api's easier, attempt to find cordova or capacitor plugins. You will need to view their (capacitorjs) docs to learn how to properly accesss those. 
 
-### Find a bug? Want to add a feature? 
+ ### Accessing Device APIs
+ CapacitorJS is/was based on Cordova and has *complete* backwards compatibility with cordova plugins. To find plugins that allow you to access the device api's easier, attempt to find cordova or capacitor plugins. You will need to view their (capacitorjs) docs to learn how to properly accesss those.
 
-Submit a PR! I would love to have more people working on this, the advantages of a system such as this vs NativeScript or React Native are innumerable especially in regards for how quickly you can get started and instant developer options and this could be built out to something great! 
+### Find a bug? Want to add a feature?
 
-### Are you using this project! Let us know! 
+Submit a PR! I would love to have more people working on this, the advantages of a system such as this vs NativeScript or React Native are innumerable especially in regards for how quickly you can get started and instant developer options and this could be built out to something great!
 
-I would love to keep a collection of all the projects using this! 
+### Are you using this project! Let us know!
+
+I would love to keep a collection of all the projects using this!
 
 -----
 

--- a/capacitor.config.json
+++ b/capacitor.config.json
@@ -11,7 +11,7 @@
   },
   "cordova": {},
   "server": {
-    "url": "http://127.0.0.1:5001",
+    "url": "http://change-me:5001",
     "cleartext": true
   }
 }


### PR DESCRIPTION
fixes #8 

Hello :]
As related on the issue, it's way easier for Android devs to use `10.0.2.2` as server URL. This PR improves the docs on the server URL topic and changes the default server URL to be an invalid one, forcing the dev to change it.

Any questions, suggestions or demands, just ping me!