### PR TITLE
Revert port change

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "#Dev: Core": "These allow the code to be developed with HMR",
       "dev:preview": "vite preview",
       "dev:start": "run-p build:routify dev:vite",
-      "dev:vite": "vite --host --port 5000",
+      "dev:vite": "vite --host --port 5001",
 
     "#Utilities": "Various utilities",
       "validate": "svelte-check"


### PR DESCRIPTION
I don't know if it was intentional but the port the server is running on was changed in the 2.0 update. This reverts that change so that the port (5001) in the capacitor config and in the README is used.